### PR TITLE
Altering v2.0 to allow for extra simple types and not requiring external definition file

### DIFF
--- a/swagger_spec_validator/__about__.py
+++ b/swagger_spec_validator/__about__.py
@@ -12,7 +12,8 @@ __title__ = "swagger-spec-validator"
 __summary__ = "Validation of Swagger specifications"
 __uri__ = "http://github.com/Yelp/swagger_spec_validator"
 
-__version__ = "2.4.3"
+# version from original repos is 2.4.3
+__version__ = "2.5.1"
 
 __author__ = "John Billings"
 __email__ = "billings@yelp.com"

--- a/swagger_spec_validator/__about__.py
+++ b/swagger_spec_validator/__about__.py
@@ -12,7 +12,7 @@ __title__ = "swagger-spec-validator"
 __summary__ = "Validation of Swagger specifications"
 __uri__ = "http://github.com/Yelp/swagger_spec_validator"
 
-# version from original repos is 2.4.3
+# version from original repos was 2.4.3
 __version__ = "2.5.1"
 
 __author__ = "John Billings"

--- a/swagger_spec_validator/__about__.py
+++ b/swagger_spec_validator/__about__.py
@@ -13,7 +13,7 @@ __summary__ = "Validation of Swagger specifications"
 __uri__ = "http://github.com/Yelp/swagger_spec_validator"
 
 # version from original repos was 2.4.3
-__version__ = "2.5.1"
+__version__ = "2.4.3.1"
 
 __author__ = "John Billings"
 __email__ = "billings@yelp.com"

--- a/swagger_spec_validator/schemas/v2.0/custom_json_schema.json
+++ b/swagger_spec_validator/schemas/v2.0/custom_json_schema.json
@@ -1,7 +1,7 @@
 {
-    "id": "/custom_job_schema.json#",
-    "$schema": "/custom_job_schema.json#",
-    "description": "Core schema meta-schema",
+    "id": "custom_job_schema.json#",
+    "$schema": "custom_job_schema.json#",
+    "description": "Custom schema meta-schema that allows for additional simple types",
     "definitions": {
         "schemaArray": {
             "type": "array",

--- a/swagger_spec_validator/schemas/v2.0/custom_json_schema.json
+++ b/swagger_spec_validator/schemas/v2.0/custom_json_schema.json
@@ -1,0 +1,149 @@
+{
+    "id": "/custom_job_schema.json#",
+    "$schema": "/custom_job_schema.json#",
+    "description": "Core schema meta-schema",
+    "definitions": {
+        "schemaArray": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#" }
+        },
+        "positiveInteger": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "positiveIntegerDefault0": {
+            "allOf": [ { "$ref": "#/definitions/positiveInteger" }, { "default": 0 } ]
+        },
+        "simpleTypes": {
+            "enum": [ "array", "boolean", "integer", "null", "number", "object", "string", "nan-number", "inf-number", "nan-inf-number" ]
+        },
+        "stringArray": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 1,
+            "uniqueItems": true
+        }
+    },
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string"
+        },
+        "$schema": {
+            "type": "string"
+        },
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "default": {},
+        "multipleOf": {
+            "type": "number",
+            "minimum": 0,
+            "exclusiveMinimum": true
+        },
+        "maximum": {
+            "type": "number"
+        },
+        "exclusiveMaximum": {
+            "type": "boolean",
+            "default": false
+        },
+        "minimum": {
+            "type": "number"
+        },
+        "exclusiveMinimum": {
+            "type": "boolean",
+            "default": false
+        },
+        "maxLength": { "$ref": "#/definitions/positiveInteger" },
+        "minLength": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+        "additionalItems": {
+            "anyOf": [
+                { "type": "boolean" },
+                { "$ref": "#" }
+            ],
+            "default": {}
+        },
+        "items": {
+            "anyOf": [
+                { "$ref": "#" },
+                { "$ref": "#/definitions/schemaArray" }
+            ],
+            "default": {}
+        },
+        "maxItems": { "$ref": "#/definitions/positiveInteger" },
+        "minItems": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "uniqueItems": {
+            "type": "boolean",
+            "default": false
+        },
+        "maxProperties": { "$ref": "#/definitions/positiveInteger" },
+        "minProperties": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "required": { "$ref": "#/definitions/stringArray" },
+        "additionalProperties": {
+            "anyOf": [
+                { "type": "boolean" },
+                { "$ref": "#" }
+            ],
+            "default": {}
+        },
+        "definitions": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "dependencies": {
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    { "$ref": "#" },
+                    { "$ref": "#/definitions/stringArray" }
+                ]
+            }
+        },
+        "enum": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "type": {
+            "anyOf": [
+                { "$ref": "#/definitions/simpleTypes" },
+                {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/simpleTypes" },
+                    "minItems": 1,
+                    "uniqueItems": true
+                }
+            ]
+        },
+        "format": { "type": "string" },
+        "allOf": { "$ref": "#/definitions/schemaArray" },
+        "anyOf": { "$ref": "#/definitions/schemaArray" },
+        "oneOf": { "$ref": "#/definitions/schemaArray" },
+        "not": { "$ref": "#" }
+    },
+    "dependencies": {
+        "exclusiveMaximum": [ "maximum" ],
+        "exclusiveMinimum": [ "minimum" ]
+    },
+    "default": {}
+}

--- a/swagger_spec_validator/schemas/v2.0/schema.json
+++ b/swagger_spec_validator/schemas/v2.0/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "custom_json_schema.json#",
     "additionalProperties": false,
     "definitions": {
         "apiKeySecurity": {
@@ -147,7 +147,7 @@
             "type": "object"
         },
         "default": {
-            "$ref": "http://json-schema.org/draft-04/schema#/properties/default"
+            "$ref": "custom_json_schema.json#/properties/default"
         },
         "definitions": {
             "additionalProperties": {
@@ -157,20 +157,20 @@
             "type": "object"
         },
         "description": {
-            "$ref": "http://json-schema.org/draft-04/schema#/properties/description"
+            "$ref": "custom_json_schema.json#/properties/description"
         },
         "enum": {
-            "$ref": "http://json-schema.org/draft-04/schema#/properties/enum"
+            "$ref": "custom_json_schema.json#/properties/enum"
         },
         "examples": {
             "additionalProperties": true,
             "type": "object"
         },
         "exclusiveMaximum": {
-            "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
+            "$ref": "custom_json_schema.json#/properties/exclusiveMaximum"
         },
         "exclusiveMinimum": {
-            "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
+            "$ref": "custom_json_schema.json#/properties/exclusiveMinimum"
         },
         "externalDocs": {
             "additionalProperties": false,
@@ -204,10 +204,10 @@
             },
             "properties": {
                 "default": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/default"
+                    "$ref": "custom_json_schema.json#/properties/default"
                 },
                 "description": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/description"
+                    "$ref": "custom_json_schema.json#/properties/description"
                 },
                 "example": {},
                 "externalDocs": {
@@ -221,10 +221,10 @@
                     "type": "boolean"
                 },
                 "required": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray"
+                    "$ref": "custom_json_schema.json#/definitions/stringArray"
                 },
                 "title": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
+                    "$ref": "custom_json_schema.json#/properties/title"
                 },
                 "type": {
                     "enum": [
@@ -575,13 +575,13 @@
             "type": "object"
         },
         "maxItems": {
-            "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+            "$ref": "custom_json_schema.json#/definitions/positiveInteger"
         },
         "maxLength": {
-            "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+            "$ref": "custom_json_schema.json#/definitions/positiveInteger"
         },
         "maximum": {
-            "$ref": "http://json-schema.org/draft-04/schema#/properties/maximum"
+            "$ref": "custom_json_schema.json#/properties/maximum"
         },
         "mediaTypeList": {
             "items": {
@@ -595,16 +595,16 @@
             "type": "string"
         },
         "minItems": {
-            "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+            "$ref": "custom_json_schema.json#/definitions/positiveIntegerDefault0"
         },
         "minLength": {
-            "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+            "$ref": "custom_json_schema.json#/definitions/positiveIntegerDefault0"
         },
         "minimum": {
-            "$ref": "http://json-schema.org/draft-04/schema#/properties/minimum"
+            "$ref": "custom_json_schema.json#/properties/minimum"
         },
         "multipleOf": {
-            "$ref": "http://json-schema.org/draft-04/schema#/properties/multipleOf"
+            "$ref": "custom_json_schema.json#/properties/multipleOf"
         },
         "nonBodyParameter": {
             "oneOf": [
@@ -1029,7 +1029,7 @@
             "type": "object"
         },
         "pattern": {
-            "$ref": "http://json-schema.org/draft-04/schema#/properties/pattern"
+            "$ref": "custom_json_schema.json#/properties/pattern"
         },
         "primitivesItems": {
             "additionalProperties": false,
@@ -1297,23 +1297,23 @@
                     "type": "array"
                 },
                 "default": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/default"
+                    "$ref": "custom_json_schema.json#/properties/default"
                 },
                 "description": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/description"
+                    "$ref": "custom_json_schema.json#/properties/description"
                 },
                 "discriminator": {
                     "type": "string"
                 },
                 "enum": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/enum"
+                    "$ref": "custom_json_schema.json#/properties/enum"
                 },
                 "example": {},
                 "exclusiveMaximum": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
+                    "$ref": "custom_json_schema.json#/properties/exclusiveMaximum"
                 },
                 "exclusiveMinimum": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
+                    "$ref": "custom_json_schema.json#/properties/exclusiveMinimum"
                 },
                 "externalDocs": {
                     "$ref": "#/definitions/externalDocs"
@@ -1337,34 +1337,34 @@
                     "default": {}
                 },
                 "maxItems": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+                    "$ref": "custom_json_schema.json#/definitions/positiveInteger"
                 },
                 "maxLength": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+                    "$ref": "custom_json_schema.json#/definitions/positiveInteger"
                 },
                 "maxProperties": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
+                    "$ref": "custom_json_schema.json#/definitions/positiveInteger"
                 },
                 "maximum": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/maximum"
+                    "$ref": "custom_json_schema.json#/properties/maximum"
                 },
                 "minItems": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+                    "$ref": "custom_json_schema.json#/definitions/positiveIntegerDefault0"
                 },
                 "minLength": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+                    "$ref": "custom_json_schema.json#/definitions/positiveIntegerDefault0"
                 },
                 "minProperties": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
+                    "$ref": "custom_json_schema.json#/definitions/positiveIntegerDefault0"
                 },
                 "minimum": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/minimum"
+                    "$ref": "custom_json_schema.json#/properties/minimum"
                 },
                 "multipleOf": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/multipleOf"
+                    "$ref": "custom_json_schema.json#/properties/multipleOf"
                 },
                 "pattern": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/pattern"
+                    "$ref": "custom_json_schema.json#/properties/pattern"
                 },
                 "properties": {
                     "additionalProperties": {
@@ -1378,16 +1378,16 @@
                     "type": "boolean"
                 },
                 "required": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray"
+                    "$ref": "custom_json_schema.json#/definitions/stringArray"
                 },
                 "title": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
+                    "$ref": "custom_json_schema.json#/properties/title"
                 },
                 "type": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/type"
+                    "$ref": "custom_json_schema.json#/properties/type"
                 },
                 "uniqueItems": {
-                    "$ref": "http://json-schema.org/draft-04/schema#/properties/uniqueItems"
+                    "$ref": "custom_json_schema.json#/properties/uniqueItems"
                 },
                 "xml": {
                     "$ref": "#/definitions/xml"
@@ -1475,10 +1475,10 @@
             "type": "object"
         },
         "title": {
-            "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
+            "$ref": "custom_json_schema.json#/properties/title"
         },
         "uniqueItems": {
-            "$ref": "http://json-schema.org/draft-04/schema#/properties/uniqueItems"
+            "$ref": "custom_json_schema.json#/properties/uniqueItems"
         },
         "vendorExtension": {
             "additionalItems": true,


### PR DESCRIPTION
This custom spec is needed by archer_web swagger docs.

Some variant columns can be NaN and infinity.
To make it completely visible which columns can be NaN and infinity we want to be able to specify them within the swagger spec. Open API 2.0 currently only allows a column type to be array, boolean, integer, null, number, object, or string. This update adds in the option to use inf-num for numbers that can be NaN, inf-num for numbers that can be Infinity and nan-inf-num for numbers that can be Infinity or NaN.

Having this custom definition file internal to this repos also makes it possible to not require external internet access for validating the spec.

custom_json_schema.json is copy of the file found at http://json-schema.org/draft-04/schema except that is adds contains 3 additional enum items in simple types definition.